### PR TITLE
Ensure all files are owned by redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,15 @@ FROM fedora:23
 RUN dnf upgrade -y && dnf clean all
 RUN dnf install -y redis-3.0.4-1.fc23 hostname && dnf clean all
 
-USER redis
-
 COPY run.sh /run.sh
 COPY redis.conf /etc/redis.conf
 COPY redis-sentinel.conf /etc/redis-sentinel.conf
+
+RUN chown redis:redis /run.sh && \
+    chown redis:redis /etc/redis.conf && \
+    chown redis:redis /etc/redis-sentinel.conf
+
+
+USER redis
 
 CMD /usr/bin/bash -c "/run.sh ${SENTINEL_HOST} ${SENTINEL_PORT}"


### PR DESCRIPTION
This helps if you need to write to /etc/redis.conf for things like require pass